### PR TITLE
Fix Initializer Arity

### DIFF
--- a/addon/initializers/router.js
+++ b/addon/initializers/router.js
@@ -3,14 +3,14 @@ import env from 'frontend/config/environment';
 
 const intercomConfig = env['ember-cli-intercom'];
 
-export function initialize(container, application) {
+export function initialize(application) {
   if (intercomConfig.logTransitions === true) {
     logTransitions(application);
   }
 }
 
 export default {
-  name: 'router',
+  name: 'intercom-router',
   initialize
 };
 


### PR DESCRIPTION
Also make initializer name more specific for easier debugging

This was causing some deprecation warnings. Perhaps wait to merge until we can be sure that this won't break releases that didn't have shas specified for github dependencies
